### PR TITLE
update clang/recipes/head.rb

### DIFF
--- a/site-cookbooks/clang/recipes/head.rb
+++ b/site-cookbooks/clang/recipes/head.rb
@@ -91,7 +91,7 @@ export LD_LIBRARY_PATH=#{with_gcc}/lib64:$LD_LIBRARY_PATH
     cd $LIBCXX_BUILD
 
     # build libcxx-head
-    CC=#{llvm_prefix}/bin/clang CXX=#{llvm_prefix}/bin/clang++ cmake -G "Unix Makefiles" -DLIBCXX_CXX_ABI=libsupc++ -DLIBCXX_LIBSUPCXX_INCLUDE_PATHS="/usr/include/c++/4.6;/usr/include/c++/4.6/x86_64-linux-gnu" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=#{libcxx_prefix} $LIBCXX_SOURCE
+    CC=#{llvm_prefix}/bin/clang CXX=#{llvm_prefix}/bin/clang++ cmake -G "Unix Makefiles" -DLIBCXX_CXX_ABI=libsupc++ -DLIBCXX_CXX_ABI_INCLUDE_PATHS="/usr/include/c++/4.6;/usr/include/c++/4.6/x86_64-linux-gnu" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=#{libcxx_prefix} $LIBCXX_SOURCE
     nice make -j2
   '
   cd #{build_dir}/libcxx-build


### PR DESCRIPTION
The option "LIBCXX_LIBSUPCXX_INCLUDE_PATHS" has been removed. Use
  "LIBCXX_CXX_ABI_INCLUDE_PATHS" instead and clean your build directory.